### PR TITLE
F# index page, a proper Italian translation

### DIFF
--- a/docs/fsharp/index.md
+++ b/docs/fsharp/index.md
@@ -1,6 +1,6 @@
 ---
 title: Guida a F#
-description: Questa guida offre una panoramica sui diversi materiali formativi disponibili su F#, un linguaggio di programmazione funzionale che gira su .NET.
+description: Questa guida offre una panoramica sui diversi materiali formativi disponibili su F#, un linguaggio di programmazione funzionale eseguito su .NET.
 author: cartermp
 ms.date: 08/03/2018
 ms.openlocfilehash: 7bba949a7567173f5f3918a6ed32aabad26fb362
@@ -12,11 +12,11 @@ ms.locfileid: "56977006"
 ---
 # <a name="f-guide"></a>Guida a F#
 
-La Guida F# fornisce molte risorse per apprendere il linguaggio F#.
+La guida F# fornisce molte risorse per apprendere il linguaggio F#.
 
-## <a name="learning-f"></a>Apprendimento di F#
+## <a name="learning-f"></a>Formazione su F#
 
-[Che cos'è F# ](what-is-fsharp.md) spiega cos'è il linguaggio F# e con piccoli esempi descrive l'esperienza di programmazione che offre. Consigliato se non si familiarità con F#.
+[Che cos'è F# ](what-is-fsharp.md) spiega cos'è il linguaggio F# e con brevi esempi di codice descrive l'esperienza di programmazione che offre. Consigliato se non si familiarità con F#.
 
 [Panoramica su F# ](tour.md) offre una panoramica sulle funzionalità principali del linguaggio, con numerosi esempi di codice. Consigliata per vedere in azione le funzionalità di base di F#.
 
@@ -24,27 +24,27 @@ La Guida F# fornisce molte risorse per apprendere il linguaggio F#.
 
 [Introduzione a F# in Visual Studio per Mac](get-started/get-started-with-visual-studio-for-mac.md) se si ha macOS e si vuole usare Visual Studio IDE.
 
-[Introduzione a F# in Visual Studio Code](get-started/get-started-vscode.md) se si vuole una esperienza ricca di funzionalità in una IDE leggera e multipiattaforma.
+[Introduzione a F# in Visual Studio Code](get-started/get-started-vscode.md) se si vuole un'esperienza ricca di funzionalità in un ambiente IDE leggero e multipiattaforma.
 
 [Introduzione a F# con la CLI di .NET Core](get-started/get-started-command-line.md) se si desidera usare gli strumenti da riga di comando.
 
 [Introduzione a F# e Xamarin](https://docs.microsoft.com/xamarin/cross-platform/platform/fsharp/) per la programmazione per dispositivi mobili con F#.
 
-[F# per Azure Notebooks](https://notebooks.azure.com/Microsoft/libraries/samples/html/FSharp%20for%20Azure%20Notebooks.ipynb) è un'esercitazione per l'apprendimento F# in un Notebook Jupyter gratuito online.
+[F# per Azure Notebooks](https://notebooks.azure.com/Microsoft/libraries/samples/html/FSharp%20for%20Azure%20Notebooks.ipynb) è un'esercitazione per l'apprendimento F# in un Notebook Jupyter ospitato gratuito.
 
 ## <a name="references"></a>Riferimenti
 
-[F# Guida di riferimento al linguaggio](language-reference/index.md) è la guida di riferimento ufficiale e completa a tutte le funzionalità di F#. Ogni articolo ne illustra la sintassi e contiene esempi di codice. È possibile usare la barra dei filtri nella tabella dei contenuti per cercare articoli specifici.
+[Guida di riferimento al linguaggio F#](language-reference/index.md) è il riferimento ufficiale e completo a tutte le funzionalità di F#. Ogni articolo ne illustra la sintassi e contiene esempi di codice. È possibile usare la barra dei filtri nella tabella dei contenuti per cercare articoli specifici.
 
-[F# Core Libreria di Riferimento](https://msdn.microsoft.com/visualfsharpdocs/conceptual/fsharp-core-library-reference) è la documentazione della API di base F#.
+[Riferimento per la Libreria principale F#](https://msdn.microsoft.com/visualfsharpdocs/conceptual/fsharp-core-library-reference) è il riferimento per la Libreria principale F#.
 
 ## <a name="additional-guides"></a>Guide aggiuntive
 
 [F# per divertimento e profitto](https://swlaschin.gitbooks.io/fsharpforfunandprofit/content/) è un libro completo e dettagliato sull'apprendimento di F#. Contenuto e autore sono molto apprezzati dalla comunità F#. I destinatari sono principalmente gli sviluppatori con conoscenze della programmazione orientata agli oggetti.
 
-[Programmare in F# Wikibook](https://en.wikibooks.org/wiki/F_Sharp_Programming) è un wikibook sull'apprendimento di F#, prodotto e mantenuto dalla comunità F#. I destinatari sono persone senza familiarità con F#, ma che hanno un po' di basi di programmazione ad oggetti.
+[Wikibook sulla programmazione in #F](https://en.wikibooks.org/wiki/F_Sharp_Programming) è un wikibook sull'apprendimento di F#, prodotto dalla comunità F#. I destinatari sono persone che non hanno familiarità con F#, ma conoscono le basi di programmazione orientata agli oggetti.
 
-## <a name="learn-f-through-videos"></a>Impara F# tramite i video
+## <a name="learn-f-through-videos"></a>Formazione F# tramite video
 
 [Esercitazione F# su YouTube](https://www.youtube.com/watch?v=c7eNDJN758U) è un'ottima introduzione all'uso di F# su Visual Studio, ricca di ottimi esempi, della durata di 1,5 ore. I destinatari sono sviluppatori Visual Studio che non hanno familiarità con F#.
 
@@ -56,7 +56,7 @@ La Guida F# fornisce molte risorse per apprendere il linguaggio F#.
 
 Il sito [F# Snippets](http://www.fssnip.net) contiene moltissimi frammenti di codice che illustrano come risolvere pressoché qualunque problema con F#, partendo dal livello "principiante assoluto" per arrivare a codice decisamente avanzato.
 
-Il [ canale Slack della F# Software Foundation](https://fsharp.org/guides/slack/) è un ottimo punto di ritrovo sia per principianti che esperti. Il canale è molto attivo e vanta alcuni dei migliori programmatori F# disponibili per la chat. Si consiglia vivamente la partecipazione.
+Il [canale Slack della F# Software Foundation](https://fsharp.org/guides/slack/) è un ottimo punto di riferimento sia per principianti che per esperti. Il canale è molto attivo e vanta alcuni dei migliori programmatori F# disponibili per una chiacchierata. L'iscrizione è vivamente consigliata.
 
 ## <a name="the-f-software-foundation"></a>F# Software Foundation
 

--- a/docs/fsharp/index.md
+++ b/docs/fsharp/index.md
@@ -1,6 +1,6 @@
 ---
 title: Guida a F#
-description: Questa guida viene fornita una panoramica della diversi materiali di formazione per F#, un linguaggio di programmazione funzionale che viene eseguita in .NET.
+description: Questa guida offre una panoramica sui diversi materiali formativi disponibili su F#, un linguaggio di programmazione funzionale che gira su .NET.
 author: cartermp
 ms.date: 08/03/2018
 ms.openlocfilehash: 7bba949a7567173f5f3918a6ed32aabad26fb362
@@ -12,56 +12,56 @@ ms.locfileid: "56977006"
 ---
 # <a name="f-guide"></a>Guida a F#
 
-Il F# Guida fornisce molte risorse per apprendere il F# language.
+La Guida F# fornisce molte risorse per apprendere il linguaggio F#.
 
-## <a name="learning-f"></a>Apprendimento F\#
+## <a name="learning-f"></a>Apprendimento di F#
 
-[Che cos'è F# ](what-is-fsharp.md) vengono descritte le operazioni di F# linguaggio e la programmazione in esso è, ad esempio, con brevi esempi di codice. Questo è consigliato se si ha familiarità con F#.
+[Che cos'è F# ](what-is-fsharp.md) spiega cos'è il linguaggio F# e con piccoli esempi descrive l'esperienza di programmazione che offre. Consigliato se non si familiarità con F#.
 
-[Panoramica del F# ](tour.md) offre una panoramica delle funzionalità del linguaggio principali con numerosi esempi di codice. Questa è consigliata se si è interessati a visualizzare core F# funzionalità in azione.
+[Panoramica su F# ](tour.md) offre una panoramica sulle funzionalità principali del linguaggio, con numerosi esempi di codice. Consigliata per vedere in azione le funzionalità di base di F#.
 
-[Introduzione a F# in Visual Studio](get-started/get-started-visual-studio.md) se si ha Windows ma si desidera che l'esperienza completa di Visual Studio IDE (Integrated Development Environment).
+[Introduzione a F# in Visual Studio](get-started/get-started-visual-studio.md) se si ha Windows e si desidera l'esperienza completa di Visual Studio IDE (Integrated Development Environment).
 
-[Introduzione a F# in Visual Studio per Mac](get-started/get-started-with-visual-studio-for-mac.md) se si ha in macOS e si vuole usare un IDE di Visual Studio.
+[Introduzione a F# in Visual Studio per Mac](get-started/get-started-with-visual-studio-for-mac.md) se si ha macOS e si vuole usare Visual Studio IDE.
 
-[Introduzione a F# in Visual Studio Code](get-started/get-started-vscode.md) se si vuole che un tipo semplice, multipiattaforma ed esperienza IDE completo di funzionalità.
+[Introduzione a F# in Visual Studio Code](get-started/get-started-vscode.md) se si vuole una esperienza ricca di funzionalità in una IDE leggera e multipiattaforma.
 
 [Introduzione a F# con la CLI di .NET Core](get-started/get-started-command-line.md) se si desidera usare gli strumenti da riga di comando.
 
 [Introduzione a F# e Xamarin](https://docs.microsoft.com/xamarin/cross-platform/platform/fsharp/) per la programmazione per dispositivi mobili con F#.
 
-[F#per Azure Notebooks](https://notebooks.azure.com/Microsoft/libraries/samples/html/FSharp%20for%20Azure%20Notebooks.ipynb) è un'esercitazione per l'apprendimento F# in un Notebook di Jupyter gratuiti, hosting.
+[F# per Azure Notebooks](https://notebooks.azure.com/Microsoft/libraries/samples/html/FSharp%20for%20Azure%20Notebooks.ipynb) è un'esercitazione per l'apprendimento F# in un Notebook Jupyter gratuito online.
 
 ## <a name="references"></a>Riferimenti
 
-[F#Riferimenti al linguaggio](language-reference/index.md) è il riferimento ufficiale e completo per tutti i F# funzionalità del linguaggio. Ogni articolo viene illustrata la sintassi e illustra esempi di codice. È possibile usare la barra del filtro nella tabella dei contenuti per gli articoli specifici.
+[F# Guida di riferimento al linguaggio](language-reference/index.md) è la guida di riferimento ufficiale e completa a tutte le funzionalità di F#. Ogni articolo ne illustra la sintassi e contiene esempi di codice. È possibile usare la barra dei filtri nella tabella dei contenuti per cercare articoli specifici.
 
-[F#Core Library Reference](https://msdn.microsoft.com/visualfsharpdocs/conceptual/fsharp-core-library-reference) è il riferimento API per il F# libreria di base.
+[F# Core Libreria di Riferimento](https://msdn.microsoft.com/visualfsharpdocs/conceptual/fsharp-core-library-reference) è la documentazione della API di base F#.
 
 ## <a name="additional-guides"></a>Guide aggiuntive
 
-[F#per divertimento e profitto](https://swlaschin.gitbooks.io/fsharpforfunandprofit/content/) è un libro molto dettagliato sull'apprendimento F#. Il contenuto e autore sono amate per il F# community. I destinatari sono principalmente gli sviluppatori con uno sfondo di programmazione orientate a oggetti.
+[F# per divertimento e profitto](https://swlaschin.gitbooks.io/fsharpforfunandprofit/content/) è un libro completo e dettagliato sull'apprendimento di F#. Contenuto e autore sono molto apprezzati dalla comunità F#. I destinatari sono principalmente gli sviluppatori con conoscenze della programmazione orientata agli oggetti.
 
-[F#Programmazione Wikibook](https://en.wikibooks.org/wiki/F_Sharp_Programming) è un wikibook sulla formazione F#. È anche un prodotto di F# community. I destinatari sono persone che hanno familiarità con F#, con un dell'oggetto orientato alla programmazione in background.
+[Programmare in F# Wikibook](https://en.wikibooks.org/wiki/F_Sharp_Programming) è un wikibook sull'apprendimento di F#, prodotto e mantenuto dalla comunità F#. I destinatari sono persone senza familiarità con F#, ma che hanno un po' di basi di programmazione ad oggetti.
 
-## <a name="learn-f-through-videos"></a>Informazioni su F# tramite i video
+## <a name="learn-f-through-videos"></a>Impara F# tramite i video
 
-[F#esercitazione su YouTube](https://www.youtube.com/watch?v=c7eNDJN758U) è un'ottima introduzione al F# usando Visual Studio, che illustra molti degli esempi nel corso di 1,5 ore. I destinatari sono gli sviluppatori di Visual Studio che hanno familiarità con F#.
+[Esercitazione F# su YouTube](https://www.youtube.com/watch?v=c7eNDJN758U) è un'ottima introduzione all'uso di F# su Visual Studio, ricca di ottimi esempi, della durata di 1,5 ore. I destinatari sono sviluppatori Visual Studio che non hanno familiarità con F#.
 
-[Introduzione alla programmazione con F# ](https://www.youtube.com/watch?v=Teak30_pXHk&list=PLEoMzSkcN8oNiJ67Hd7oRGgD1d4YBxYGC) è una serie di video eccezionale che Usa Visual Studio Code come l'editor principale. La serie di video inizia da zero e termina con la creazione di un gioco di video RPG basata su testo. I destinatari sono gli sviluppatori che preferiscono Visual Studio Code (o un IDE leggero) e nuovi per F#.
+[Introduzione alla programmazione con F# ](https://www.youtube.com/watch?v=Teak30_pXHk&list=PLEoMzSkcN8oNiJ67Hd7oRGgD1d4YBxYGC) è una serie di video eccezionali nei quali si usa Visual Studio Code come editor principale. La serie inizia da zero e termina con la creazione di un gioco di ruolo testuale. I destinatari sono sviluppatori che preferiscono Visual Studio Code (o un IDE leggero) e non hanno familiarità con F#.
 
-[What ' s New in Visual Studio 2017 per F# per gli sviluppatori](https://www.linkedin.com/learning/what-s-new-in-visual-studio-2017-for-f-sharp-for-developers) è un'esercitazione video che illustra alcune delle funzionalità più recenti per F# in Visual Studio 2017. I destinatari sono gli sviluppatori di Visual Studio che hanno familiarità con F#.
+[Novità per gli sviluppatori F# in Visual Studio 2017](https://www.linkedin.com/learning/what-s-new-in-visual-studio-2017-for-f-sharp-for-developers) è un video corso che illustra alcune delle nuove funzionalità recenti per F# presenti in Visual Studio 2017. I destinatari sono sviluppatori Visual Studio che non hanno familiarità con F#.
 
 ## <a name="other-useful-resources"></a>Altre risorse utili
 
-Il [ F# sito Web di frammenti di codice](http://www.fssnip.net) contiene un set di grandi dimensioni di frammenti di codice che illustra come eseguire pressoché qualsiasi operazione F#, compreso tra "absolute Beginner" di frammenti di codice altamente avanzate.
+Il sito [F# Snippets](http://www.fssnip.net) contiene moltissimi frammenti di codice che illustrano come risolvere pressoché qualunque problema con F#, partendo dal livello "principiante assoluto" per arrivare a codice decisamente avanzato.
 
-Il [ F# Software Foundation Slack](https://fsharp.org/guides/slack/) è un ottimo punto di partenza per principianti ed esperti nello stesso modo, è molto attiva e presenta alcune funzionalità di meglio del mondo F# i programmatori disponibili per la chat. Si consiglia di unione.
+Il [ canale Slack della F# Software Foundation](https://fsharp.org/guides/slack/) è un ottimo punto di ritrovo sia per principianti che esperti. Il canale è molto attivo e vanta alcuni dei migliori programmatori F# disponibili per la chat. Si consiglia vivamente la partecipazione.
 
 ## <a name="the-f-software-foundation"></a>F# Software Foundation
 
-Sebbene Microsoft sia lo sviluppatore principale del F# linguaggio e dei relativi strumenti in Visual Studio F# è anche supportato da una Fondazione indipendente, la F# Software Foundation (FSSF).
+Sebbene Microsoft sia lo sviluppatore principale del linguaggio F# e dei relativi strumenti in Visual Studio, F# è supportato da una Fondazione indipendente, la F# Software Foundation (FSSF).
 
 La missione della F# Software Foundation è promuovere, proteggere e migliorare il linguaggio di programmazione F# e supportare e agevolare la crescita di una comunità varia e internazionale di programmatori F#.
 
-Per altre informazioni e per prendere parte a questa iniziativa, vedere [fsharp.org](https://fsharp.org). È libero di join e la rete di F# gli sviluppatori in foundation è qualcosa che non si desidera continuare ad avvalerti!
+Per altre informazioni e per prendere parte a questa iniziativa, vedere [fsharp.org](https://fsharp.org). Diventare membri della fondazione è gratuito, ed la rete di sviluppatori F# che vi partecipa è qualcosa che non dovresti perderti!


### PR DESCRIPTION
The automatic translation does a very poor job at conveying the original
content.

Over time, in an attempt to encourage F# adoption by the Italian
developer community, it is my intention to work on a proper Italian
translation of the F# documentation or, at the very least, of its
beginner sections like what-is-fsharp, tour, and the various
get-started pages, etc.